### PR TITLE
add optional projectId on feedback

### DIFF
--- a/melodi/feedback/data_models.py
+++ b/melodi/feedback/data_models.py
@@ -11,6 +11,8 @@ class BaseFeedback(BaseModel):
     feedbackText: Optional[str] = None
 
 class Feedback(BaseFeedback):
+    projectId: Optional[int] = None
+
     externalThreadId: Optional[str] = None
     externalMessageId: Optional[str] = None
 
@@ -30,6 +32,7 @@ class AttributeOption(BaseModel):
 
 class FeedbackResponse(BaseFeedback):
     id: int
+    projectId: int
 
     externalUserId: Optional[int] = None
     externalUser: Optional[UserResponse] = None

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name='melodi',
-    version='0.1.25',
+    version='0.1.26',
     packages=find_packages(),
     install_requires=[
         'requests',


### PR DESCRIPTION
Because toast is double writing the ask tj stuff and if there are two threads with the same externalId you need to specify projectId on the feedback